### PR TITLE
refactor: clippy errors

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -54,11 +54,14 @@ pub struct Client {
     enable_cache: bool,
     api_version: ApiVersion,
     cache_lang: Arc<Mutex<Vec<Language>>>,
+    #[allow(clippy::struct_field_names)]
     client: reqwest::Client,
 }
 
 impl Client {
     // Creates a new Client instance with default settings.
+    /// # Errors
+    /// This can return an error if the Client cannot be constructed or if the HTTP request used to populate the cache fails.
     pub async fn new() -> Result<Self, Error> {
         let api_version = ApiVersion::default();
         let runtime_url = build_url("https://emkc.org", api_version, RUNTIMES_PATH);
@@ -84,6 +87,7 @@ impl Client {
     }
 
     // Sets the API version to be used in subsequent calls
+    #[must_use]
     pub fn api_version(self, version: ApiVersion) -> Self {
         Self {
             api_version: version,
@@ -91,6 +95,7 @@ impl Client {
         }
     }
 
+    #[must_use]
     // Sets the base URL for the Piston API. Rebuilds internal URLs
     pub fn base_url<T: AsRef<str>>(self, url: T) -> Self {
         let runtime_url = build_url(url.as_ref(), self.api_version, RUNTIMES_PATH);
@@ -102,6 +107,7 @@ impl Client {
         }
     }
 
+    #[must_use]
     // Disables language information caching
     pub fn disable_cache(self) -> Self {
         Self {
@@ -111,6 +117,8 @@ impl Client {
     }
 
     // Sets a custom user agent for HTTP requests
+    /// # Errors
+    /// This can return an error if the `Client` cannot be constructed.
     pub fn user_agent<T: AsRef<str>>(self, agent: T) -> Result<Self, Error> {
         let client = reqwest::ClientBuilder::new()
             .user_agent(agent.as_ref())
@@ -119,12 +127,17 @@ impl Client {
         Ok(Self { client, ..self })
     }
 
+    #[must_use]
     // Sets a custom `reqwest::Client` instance for HTTP requests
-    pub fn custom_client(self, client: reqwest::Client) -> Result<Self, Error> {
-        Ok(Self { client, ..self })
+    pub fn custom_client(self, client: reqwest::Client) -> Self {
+        Self { client, ..self }
     }
 
     // Updates the cached language information from the Piston API
+    /// # Errors
+    /// It can return an error if the HTTP request fails in the `send` method, or also if the JSON body is invalid when using the `json` method
+    /// # Panics
+    /// It can panic if the `lock` operation fails.
     pub async fn refresh_cache(self) -> Result<Self, Error> {
         let result = self.client.get(&self.runtime_url).send().await?;
         let result = result.json::<Vec<Language>>().await?;
@@ -134,6 +147,10 @@ impl Client {
 
     // Retrieves a list of supported languages and their versions.
     // Uses the language cache if enabled, otherwise fetches data from the API.
+    /// # Errors 
+    /// It can return an error if the HTTP operation fails.
+    /// # Panics
+    /// It can panic if the `lock` operation fails
     pub async fn get_languages(&self) -> Result<Vec<Language>, Error> {
         if self.enable_cache {
             let cache = self.cache_lang.as_ref().lock().unwrap();
@@ -146,6 +163,10 @@ impl Client {
 
     // Gets the version for a specific programming language.
     // Uses the language cache if enabled, otherwise fetches data from the API.
+    /// # Errors
+    /// It can return an error if the HTTP request fails in the `send` method, or also if the JSON body is invalid when using the `json` method
+    /// # Panics
+    /// It can panic if the `lock` operation fails.
     pub async fn lang_version<T: ToString>(&self, lang: T) -> Result<String, Error> {
         let langs = if self.enable_cache {
             let cache = self.cache_lang.as_ref().lock().unwrap();
@@ -193,6 +214,8 @@ impl Client {
 
     // Executes code provided as language and an iterator of `FileData` structs.
     // Retrieves the language version and calls `exec` internally.
+    /// # Errors
+    /// It can produce an error if either `lang_version` fails or `exec` fails.
     pub async fn run_files<T, U, I>(&self, lang: T, content: I) -> Result<Response, Error>
     where
         T: ToString + Clone,
@@ -207,6 +230,8 @@ impl Client {
 
     // Executes code provided as language, version, and content string.
     // Creates a single `FileData` struct from the content and calls `exec` internally.
+    /// # Errors
+    /// It can produce an error only if `exec` fails.
     pub async fn run_with_version<T: ToString + Clone>(
         &self,
         lang: T,
@@ -227,6 +252,8 @@ impl Client {
 
     // Executes code provided as language and content string.
     // Retrieves the language version and calls `run_with_version` internally.
+    /// # Errors
+    /// It can produce an error if either `lang_version` fails or `exec` fails.
     pub async fn run<T: ToString + Clone, U: ToString>(
         &self,
         lang: T,

--- a/src/client.rs
+++ b/src/client.rs
@@ -147,7 +147,7 @@ impl Client {
 
     // Retrieves a list of supported languages and their versions.
     // Uses the language cache if enabled, otherwise fetches data from the API.
-    /// # Errors 
+    /// # Errors
     /// It can return an error if the HTTP operation fails.
     /// # Panics
     /// It can panic if the `lock` operation fails


### PR DESCRIPTION
This PR refactors the code to eliminate most of Clippy’s warnings.

I'm only using one `allow`, and it's in this part:
```rust
#[allow(clippy::struct_field_names)]
client: reqwest::Client,
```